### PR TITLE
fixed partial records error

### DIFF
--- a/pydarnio/dmap/superdarn.py
+++ b/pydarnio/dmap/superdarn.py
@@ -484,6 +484,7 @@ class SDarnRead(DmapRead):
         # boundary to the map file. See missing_field_check
         # method in SDarnUtilities for more information.
         file_struct_list = [superdarn_formats.Map.types,
+                            superdarn_formats.Map.partial_fields,
                             superdarn_formats.Map.extra_fields,
                             superdarn_formats.Map.fit_fields,
                             superdarn_formats.Map.hmb_fields,

--- a/pydarnio/dmap/superdarn_formats.py
+++ b/pydarnio/dmap/superdarn_formats.py
@@ -310,7 +310,9 @@ class Map():
         'w.min': 'f',
         'w.max': 'f',
         've.min': 'f',
-        've.max': 'f',
+        've.max': 'f'
+        }
+    partial_fields = {
         'vector.mlat': 'f',
         'vector.mlon': 'f',
         'vector.kvect': 'f',


### PR DESCRIPTION
Issue: #17 

When reading partial records in map files it seems the `vector` fields can go missing. 

# Test

```
import pydarnio

file = "20120309.north.map"
reader = pydarnio.SDarnread(file)
map_data.read_map()
```

Should run smoothly no errors. 