### PR TITLE
Rawacf dmap conversion

### DIFF
--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -42,6 +42,7 @@ Update noise values in SDarn fields when these can be calculated.
 """
 import logging
 import numpy as np
+import deepdish as dd
 
 from datetime import datetime
 from typing import Union
@@ -417,10 +418,31 @@ class BorealisConvert(BorealisRead):
             for record_key, record in self.borealis_records.items():
                 sample_spacing = int(record['tau_spacing'] /
                                      record['tx_pulse_len'])
-                normal_blanked_1 = record['pulses'] * sample_spacing
-                normal_blanked_2 = normal_blanked_1 + 1
-                blanked = np.concatenate((normal_blanked_1, normal_blanked_2))
-                blanked = np.sort(blanked)
+
+                # Check to see if tagged version. If not, use 255.255
+                if record['borealis_git_hash'][0] == 'v' and \
+                        record['borealis_git_hash'][2] == '.':
+                    borealis_major_revision = record['borealis_git_hash'][1]
+                    borealis_minor_revision = record['borealis_git_hash'][3]
+                else:
+                    borealis_major_revision = 255
+                    borealis_minor_revision = 255
+
+                if borealis_major_revision == 0 and borealis_minor_revision <= 5:
+                    # Rawacf generated with borealis v0.5 or older
+                    blanked = record['pulses'] * sample_spacing
+                else:
+                    # Rawacf generated with borealis v0.6 or newer, or untagged version
+                    normal_blanked_1 = record['pulses'] * sample_spacing
+                    if normal_blanked_1 == record['blanked_samples']:
+                        # If file generated with untagged borealis version, it could be like v0.5
+                        # and still have valid blanked samples, so we check that
+                        blanked = normal_blanked_1
+                    else:
+                        normal_blanked_2 = normal_blanked_1 + 1
+                        blanked = np.concatenate((normal_blanked_1, normal_blanked_2))
+                        blanked = np.sort(blanked)
+
                 if not np.array_equal(record['blanked_samples'], blanked):
                     raise borealis_exceptions.\
                             BorealisConvert2RawacfError(

--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -364,10 +364,11 @@ class BorealisConvert(BorealisRead):
                                      record['tx_pulse_len'])
 
                 # Check to see if tagged version. If not, use 255.255
-                if record['borealis_git_hash'][0] == 'v' and \
-                        record['borealis_git_hash'][2] == '.':
-                    borealis_major_revision = record['borealis_git_hash'][1]
-                    borealis_minor_revision = record['borealis_git_hash'][3]
+                git_hash = record['borealis_git_hash'].split('-')[0]
+                major_version, minor_version = git_hash.split('.')
+                if major_version[0] == 'v':
+                    borealis_major_revision = major_version[1:]
+                    borealis_minor_revision = minor_version
                 else:
                     borealis_major_revision = 255
                     borealis_minor_revision = 255
@@ -390,7 +391,7 @@ class BorealisConvert(BorealisRead):
                 if not np.array_equal(record['blanked_samples'], blanked):
                     raise borealis_exceptions.\
                             BorealisConvert2IqdatError(
-                                'Increased complexity: Borealis rawacf file'
+                                'Increased complexity: Borealis bfiq file'
                                 ' record {} blanked_samples {} is not correct'
                                 ' for pulses array converted to sample number '
                                 '{} * {}.'.format(record_key,
@@ -444,10 +445,11 @@ class BorealisConvert(BorealisRead):
                                      record['tx_pulse_len'])
 
                 # Check to see if tagged version. If not, use 255.255
-                if record['borealis_git_hash'][0] == 'v' and \
-                        record['borealis_git_hash'][2] == '.':
-                    borealis_major_revision = record['borealis_git_hash'][1]
-                    borealis_minor_revision = record['borealis_git_hash'][3]
+                git_hash = record['borealis_git_hash'].split('-')[0]
+                major_version, minor_version = git_hash.split('.')
+                if major_version[0] == 'v':
+                    borealis_major_revision = major_version[1:]
+                    borealis_minor_revision = minor_version
                 else:
                     borealis_major_revision = 255
                     borealis_minor_revision = 255

--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -851,6 +851,20 @@ class BorealisConvert(BorealisRead):
                 # place the SDARN-style array in the dict
                 correlation_dict[key] = new_data
 
+            # AGC Status Word only introduced in Borealis v0.6 onwards,
+            # so it can be set to zero if not present
+            if 'agc_status_word' not in record_dict.keys():
+                agc_sw = 0
+            else:
+                agc_sw = record_dict['agc_status_word']
+
+            # Low Power Status Word only introduced in Borealis v0.6 onwards,
+            # so it can be set to zero if not present
+            if 'lp_status_word' not in record_dict.keys():
+                lp_sw = 0
+            else:
+                lp_sw = record_dict['lp_status_word']
+
             sdarn_record_dict = {
                 'radar.revision.major': np.int8(borealis_major_revision),
                 'radar.revision.minor': np.int8(borealis_minor_revision),
@@ -899,8 +913,8 @@ class BorealisConvert(BorealisRead):
                 'lagfr': np.int16(record_dict['first_range_rtt']),
                 'smsep': np.int16(1e6/record_dict['rx_sample_rate']),
                 'ercod': np.int16(0),
-                'stat.agc': np.int16(record_dict['agc_status_word']),
-                'stat.lopwr': np.int16(record_dict['lp_status_word']),
+                'stat.agc': np.int16(agc_sw),
+                'stat.lopwr': np.int16(lp_sw),
                 # TODO: currently not implemented
                 'noise.search': np.float32(record_dict['noise_at_freq'][0]),
                 # TODO: currently not implemented

--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -613,6 +613,20 @@ class BorealisConvert(BorealisRead):
 
             int_data = np.array(int_data, dtype=np.int16)
 
+            # AGC Status Word only introduced in Borealis v0.6 onwards,
+            # so it can be set to zero if not present
+            if 'agc_status_word' not in record_dict.keys():
+                agc_sw = 0
+            else:
+                agc_sw = record_dict['agc_status_word']
+
+            # Low Power Status Word only introduced in Borealis v0.6 onwards,
+            # so it can be set to zero if not present
+            if 'lp_status_word' not in record_dict.keys():
+                lp_sw = 0
+            else:
+                lp_sw = record_dict['lp_status_word']
+
             # flattening done in convert_to_dmap_datastructures
             sdarn_record_dict = {
                 'radar.revision.major': np.int8(borealis_major_revision),
@@ -662,8 +676,8 @@ class BorealisConvert(BorealisRead):
                 # smsep is in us; conversion from seconds
                 'smsep': np.int16(1e6 / record_dict['rx_sample_rate']),
                 'ercod': np.int16(0),
-                'stat.agc': np.int16(record_dict['agc_status_word']),
-                'stat.lopwr': np.int16(record_dict['lp_status_word']),
+                'stat.agc': np.int16(agc_sw),
+                'stat.lopwr': np.int16(lp_sw),
                 # TODO: currently not implemented
                 'noise.search': np.float32(record_dict['noise_at_freq'][0]),
                 # TODO: currently not implemented


### PR DESCRIPTION
# Scope 

*Patch to fix bfiq -> iqdat and rawacf hdf5 -> dmap conversions*

**Issue:**
These conversions fail for Borealis v0.5 files. In v0.5, only the samples corresponding to a tx pulse are blanked, but in v0.6 the immediately following sample is blanked as well. Additionally, v0.5 files don't have a field for `agc_status_word` and `lp_status_word`, which are necessary fields in the iqdat and rawacf dmap files.

## Approval

**Number of approvals:** 2

## Test

Methods changed are all in `borealis_convert.py`:
 - `_is_convertible_to_iqdat()`
 - `_is_convertible_to_rawacf()`
 - `__convert_bfiq_record()`
 - `__convert_rawacf_record()`
These are run by calling `BorealisConvert()` for bfiq and rawacf files, respectively.