### PR TITLE
Bugfix: Nan assignment of integer types

### DIFF
--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -936,7 +936,10 @@ class BaseFormat():
             # initialize all values to NaN; some indices may not be filled
             # do to dimensions that are max values (num sequences, etc can
             # change between records)
-            empty_array[:] = np.NaN
+            if datatype is np.int64 or datatype is np.uint32:
+                empty_array[:] = -1
+            else:
+                empty_array[:] = np.NaN
             temp_array_dict[field] = empty_array
 
         # iterate through the records, filling the unshared and array only

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -933,9 +933,9 @@ class BaseFormat():
                 # multiple chars (256)
                 datatype='|U256'
             empty_array = np.empty(array_dims, dtype=datatype)
-            # initialize all values to NaN; some indices may not be filled
-            # do to dimensions that are max values (num sequences, etc can
-            # change between records)
+            # Some indices may not be filled due to dimensions that are maximum values (num_sequences, etc. can change
+            # between records), so they are initialized with a known value first.
+            # Initialize floating-point values to NaN, and integer values to -1.
             if datatype is np.int64 or datatype is np.uint32:
                 empty_array[:] = -1
             else:


### PR DESCRIPTION
Initialize int-type arrays to -1 to avoid ValueError when assigning nan's to int array.

* unsigned ints (blanked_samples and beam_nums) will overflow

# Scope 

Fixes exception raised when trying to assign nan-values to integer type.

**Issue:** https://github.com/SuperDARN/pyDARNio/issues/29

## Approval

**Number of approvals:** *1*

## Test

```python3
from pydarnio import BorealisRead
filename = '20211006.2132.00.sas.0.rawacf.hdf5.site'    # path to your rawacf file here
borealis_filetype = 'rawacf'
borealis_reader = BorealisRead(filename, borealis_filetype, borealis_file_structure='site')
arrays = borealis_reader.arrays
```