### PR TITLE
Remove far lag0 replacement when converting rawacf hdf5 files to dmap.

### DIFF
--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -855,7 +855,14 @@ class BorealisConvert(BorealisRead):
         for beam_index, beam in enumerate(record_dict['beam_nums']):
             # this beam, all ranges lag 0
             lag_zero = shaped_data['main_acfs'][beam_index, :, 0]
-            lag_zero[-10:] = shaped_data['main_acfs'][beam_index, -10:, -1]
+
+            # Historically, the following line was un-commented. It's purpose was to replace the lag0 data for far
+            # ranges which were contaminated by the second pulse in a sequence. However, it only worked for a small
+            # subset of conditions; specifically, it failed for experiments where the second pulse occurred earlier
+            # or the number of range gates was larger than normal. This replacement is now handled in borealis, and
+            # is more flexible to deal with the variety of different conditions possible from experiments.
+            # lag_zero[-10:] = shaped_data['main_acfs'][beam_index, -10:, -1]
+
             lag_zero_power = (lag_zero.real**2 + lag_zero.imag**2)**0.5
 
             correlation_dict = {}

--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -869,13 +869,11 @@ class BorealisConvert(BorealisRead):
             for key in shaped_data:
                 # num_ranges x num_lags (complex)
                 this_correlation = shaped_data[key][beam_index, :, :-1]
-                # set the lag0 to the alternate lag0 for the end of the
-                # array (when interference of first pulse would occur)
-                this_correlation[-10:, 0] = \
-                    shaped_data[key][beam_index, -10:, -1]
-                # shape num_beams x num_ranges x num_la gs, now
-                # num_ranges x num_lags-1 b/c alternate lag-0 combined
-                # with lag-0 (only used for last ranges)
+
+                ##### Similar to above, this line has been commented out to avoid far-range lag0 replacement
+                ##### as it is now handled in borealis.
+                # this_correlation[-10:, 0] = \
+                #     shaped_data[key][beam_index, -10:, -1]
 
                 # (num_ranges x num_lags, flattened)
                 flattened_data = np.array(this_correlation).flatten()


### PR DESCRIPTION
# Scope 

Small bugfix, commented out one line with an explanation why.

**Issue:**
Addresses issue with replacement of far-range lag0 data with alternate lag0 samples. The last 10 ranges were being replaced, which was a hard-coded value that only really worked well for experiments where the second pulse in a sequence landed in the last 10 samples of lag0 (normalscan and twofsound for 75-range gate radars). It failed when this was not the case, such as for the PolarDARN radars which used to scan 100 range gates. 

## Approval

**Number of approvals:** *1*

## Test

Convert any borealis rawacf file (currently borealis is not doing the replacement, so any borealis file should work) and convert to DMAP, then check if the last 10 ranges of the lag0 data are equal to the last 10 ranges of the alternate lag0 data. 

```python3
import pydarnio
import numpy as np

borealis_file = "path to borealis file"
sdarn_file = "location to save dmap file"
converter = pydarnio.BorealisConvert(borealis_file, 'rawacf', sdarn_file)

# Get the far-range lag0 DMAP data
sdarn_dict = converter.sdarn_dict
acfd = sdarn_dict[0]['acfd']
corrs = acfd[:, :, 0] + 1j * acfd[:, :, 1]
far_ranges = corrs[-10:, 0]

# Get the far-range alternate lag0 HDF5 data
combf = sdarn_dict[0]['combf']
words = combf.split()
# record timestamp stored in combf field
index = words.index('record') + 1
timestamp = words[index]
reader = pydarnio.BorealisRead(borealis_file, 'rawacf', borealis_file_structure='site')
records = reader.records
record = records[timestamp]
main_acfs = record['main_acfs']
main_acfs = main_acfs.reshape(record['correlation_dimensions'])
alt_lag0 = main_acfs[0, :, -1]
far_ranges_alt = alt_lag0[-10:]

# Get the far-range lag0 data from the HDF5 file
far_ranges_lag0 = main_acfs[0, -10:, 0]

# Correct for scaling factor and normalization
far_ranges_alt *= ((np.iinfo(np.int16).max**2 / (record['data_normalization_factor']**2))
far_ranges_lag0 *= ((np.iinfo(np.int16).max**2 / (record['data_normalization_factor']**2))

# far_ranges should match far_ranges_lag0, but not match far_ranges_alt
if not np.allclose(far_ranges, far_ranges_alt) and np.allclose(far_ranges, far_ranges_lag0):
    print("Success! No lag0 replacement")
else:
    print("Failure. DMAP lag0 does not match HDF5 lag0 data.")
```
