### PR TITLE
Release pyDARNio

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,15 +5,11 @@
         },
         {
             "affiliation": "University of Saskatchewan",
+            "name": "Rohel, R.A."
+        },
+        {
+            "affiliation": "University of Saskatchewan",
             "name": "Krieger, K.J."
-        },
-        {
-            "affiliation": "University of Saskatchewan",
-            "name": "Kotyk, K."
-        },
-        {
-            "affiliation": "University of Saskatchewan",
-            "name": "Detwiller, M.H."
         },
         {
             "affiliation": "University of Saskatchewan",
@@ -24,6 +20,14 @@
             "affiliation": "US Naval Research Laboratory",
             "name": "Burrell, A.G.",
             "orcid": "0000-0001-8875-9326"
+        },
+        {
+            "affiliation": "University of Saskatchewan",
+            "name": "Detwiller, M.H."
+        },
+        {
+            "affiliation": "University of Saskatchewan",
+            "name": "Kotyk, K."
         },
         {
             "affiliation": "University of Saskatchewan",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,6 +8,11 @@
             "name": "Rohel, R.A."
         },
         {
+            "affiliation": "John Hopkins University",
+            "name": "Chartier, A.",
+            "orcid": "0000-0002-4215-031X"
+        },
+        {
             "affiliation": "University of Saskatchewan",
             "name": "Krieger, K.J."
         },

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Python data IO library for the Super Dual Auroral Radar Network (SuperDARN).
 
 ## Changelog
 
-## Version 1.1 - Release!
+## Version 1.1.1 - Release!
 
-pyDARNio is released! Included are the following features:
-- Reading and writing of Borealis v0.6 HDF5 files
-- Bug fix with Slice interface with Borealis files
-- Bug fix on reading partial records with MAP DMAP files
+pyDARNio is released! This is a patch release to address the following issues:
+- Bug fix with initializing empty arrays when converting HDF5 files from site- to array-structured
+- Bug fixes with converting files from HDF5 to DMAP
+  - correctly check blanked_samples
+  - support multiple beams per record
+  - replacement of far-range lag0 data in rawacf conversion
 
 ## Documentation
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 # Setup information
 setup(
     name="pydarnio",
-    version="1.1.0",
+    version="1.1.1",
     long_description=long_description,
     long_description_content_type='text/markdown',
     description="Python library for reading and writing SuperDARN data",


### PR DESCRIPTION
# Scope 

- Fixes initialization of int arrays to NaN's when restructuring Borealis files from site to array
- Fixes conversion from HDF5 to DMAP:
  - Records with multiple beams can now be converted
  - Correctly checks blanked_samples for both Borealis v0.5 and older files, and Borealis v0.6 files
  - No longer replaces last 10 lag0 samples for rawacf data

## Approval

**Number of approvals:** *3*
**Due Date:** *January 21st, 2022*

## Test

- [x] Test on RPM Linux (OpenSuse, Fedora, RedHat)
- [ ] Test on Debian Linux (Ubuntu)
- [x] Test on Mac OSX
- [ ] Test on Windows (if possible)

To test HDF5 to DMAP conversion:

```python3
from pydarnio import BorealisConvert
filename = # path to bfiq or rawacf file
borealis_filetype = # 'bfiq' or 'rawacf'
dmap_filename = # path where you want to store dmap file
borealis_converter = BorealisConvert(filename, borealis_filetype,
dmap_filename, borealis_file_structure='site' or 'array')
```
Sample HDF5 files can be found here: https://drive.google.com/drive/folders/1j37Ez6JY_IlNAYXx2kG6IGR3aWzhMNMi. Test all files, as some are Borealis v0.5 and some are v0.6.

To test site to array restructuring:

```python3
from pydarnio import BorealisRead
filename = # path to HDF5
borealis_filetype = 'rawacf' or 'bfiq' or 'antennas_iq'
borealis_reader = BorealisRead(filename, borealis_filetype, borealis_file_structure='site')
arrays = borealis_reader.arrays
```

Verify that this error is not raised: `Error restructuring BorealisRawacfv0_5 from site to array style: cannot convert float NaN to integer`
Try with an antennas_iq, bfiq, and rawacf file, if possible.

To test multi-beam record conversion:

```python3
import pydarnio

infile = "path to borealis file with multi-beam records"
file_type = "rawacf" or "bfiq"
file_structure = "site" or "array"
sdarn_file = "path to output sdarn file"

converter = pydarnio.BorealisConvert(infile, file_type, sdarn_file, borealis_file_structure=file_structure)
```

Plot with pyDARN to verify that conversion was successful. For rawacf data, you can find instructions here: https://pydarn.readthedocs.io/en/main/user/range_time/
Contact remington.rohel@usask.ca for multi-beam data.

To test lag0 replacement:

```python3
import pydarnio
import numpy as np

borealis_file = "path to borealis file"
sdarn_file = "location to save dmap file"
converter = pydarnio.BorealisConvert(borealis_file, 'rawacf', sdarn_file)

# Get the far-range lag0 DMAP data
sdarn_dict = converter.sdarn_dict
acfd = sdarn_dict[0]['acfd']
corrs = acfd[:, :, 0] + 1j * acfd[:, :, 1]
far_ranges = corrs[-10:, 0]

# Get the far-range alternate lag0 HDF5 data
combf = sdarn_dict[0]['combf']
words = combf.split()
# record timestamp stored in combf field
index = words.index('record') + 1
timestamp = words[index]
reader = pydarnio.BorealisRead(borealis_file, 'rawacf', borealis_file_structure='site')
records = reader.records
record = records[timestamp]
main_acfs = record['main_acfs']
main_acfs = main_acfs.reshape(record['correlation_dimensions'])
alt_lag0 = main_acfs[0, :, -1]
far_ranges_alt = alt_lag0[-10:]

# Get the far-range lag0 data from the HDF5 file
far_ranges_lag0 = main_acfs[0, -10:, 0]

# Correct for scaling factor and normalization
far_ranges_alt *= ((np.iinfo(np.int16).max**2 / (record['data_normalization_factor']**2))
far_ranges_lag0 *= ((np.iinfo(np.int16).max**2 / (record['data_normalization_factor']**2))

# far_ranges should match far_ranges_lag0, but not match far_ranges_alt
if not np.allclose(far_ranges, far_ranges_alt) and np.allclose(far_ranges, far_ranges_lag0):
    print("Success! No lag0 replacement")
else:
    print("Failure. DMAP lag0 does not match HDF5 lag0 data.")
```

Any HDF5 rawacf file is sufficient for testing.