### PR TITLE
Updated experiment_id type for Borealis v0.6 files.

### DIFF
--- a/pydarnio/borealis/borealis_formats.py
+++ b/pydarnio/borealis/borealis_formats.py
@@ -1824,7 +1824,10 @@ class BorealisRawacf(BorealisRawacfv0_5):
             "gps_locked": np.bool_,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
-            "gps_to_system_time_diff": np.float64
+            "gps_to_system_time_diff": np.float64,
+            # Updated to 16 bit number to avoid mismatch when converting
+            # to DMAP format.
+            "experiment_id": np.int16
         })
         return single_element_types
 
@@ -1929,7 +1932,10 @@ class BorealisBfiq(BorealisBfiqv0_5):
             "gps_locked": np.bool_,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
-            "gps_to_system_time_diff": np.float64
+            "gps_to_system_time_diff": np.float64,
+            # Updated to 16 bit number to avoid mismatch when converting
+            # to DMAP format.
+            "experiment_id": np.int16
         })
         return single_element_types
 
@@ -1970,7 +1976,7 @@ class BorealisBfiq(BorealisBfiqv0_5):
             'gps_to_system_time_diff': [],
             'pulse_phase_offset': [lambda arrays, record_num:
                             0 if (arrays['pulse_phase_offset'].shape[1] == 0)
-                            else 
+                            else
                             list((arrays['num_sequences'][record_num],) +
                             arrays['pulse_phase_offset'][record_num].shape[1:])],
             })
@@ -2040,7 +2046,10 @@ class BorealisAntennasIq(BorealisAntennasIqv0_5):
             "gps_locked": np.bool_,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
-            "gps_to_system_time_diff": np.float64
+            "gps_to_system_time_diff": np.float64,
+            # Updated to 16 bit number to avoid mismatch when converting
+            # to DMAP format.
+            "experiment_id": np.int16
         })
         return single_element_types
 
@@ -2140,7 +2149,10 @@ class BorealisRawrf(BorealisRawrfv0_5):
             "gps_locked": np.bool_,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
-            "gps_to_system_time_diff": np.float64
+            "gps_to_system_time_diff": np.float64,
+            # Updated to 16 bit number to avoid mismatch when converting
+            # to DMAP format.
+            "experiment_id": np.int16
         })
         return single_element_types
 


### PR DESCRIPTION
# Scope 

*Minor change to experiment_id field of Borealis v0.6 files*

## Approval

**Number of approvals:** *1*

## Test

```python3
>>> import pydarnio
>>> filetypes = ['antennas_iq', 'bfiq', 'rawacf']
>>> basename = '20220915.1938.03.sas.0.{}.hdf5.site'
>>> for ftype in filetypes:
...     filename = basename.format(ftype)
...     try:
...             borealis_reader = pydarnio.BorealisRead(filename, ftype, 'site')
...     except:
...             print('Failure to read {}'.format(filename))
```

Verify that nothing gets printed when this code is run! Example files here: [test_files.zip](https://github.com/SuperDARN/pyDARNio/files/9658029/test_files.zip)


