### PR TITLE
Bugfix/borealis dmap versioning

### DIFF
--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -363,12 +363,12 @@ class BorealisConvert(BorealisRead):
                 sample_spacing = int(record['tau_spacing'] /
                                      record['tx_pulse_len'])
 
-                # Check to see if tagged version. If not, use 255.255
-                git_hash = record['borealis_git_hash'].split('-')[0]
-                major_version, minor_version = git_hash.split('.')
-                if major_version[0] == 'v':
-                    borealis_major_revision = major_version[1:]
-                    borealis_minor_revision = minor_version
+                # Borealis git tag version numbers. If not a tagged version,
+                # then use 255.255
+                if record['borealis_git_hash'][0] == 'v':  # tagged version, non-tagged versions have hexadecimal
+                    version = record['borealis_git_hash'].split('-')[0].split('.')
+                    borealis_major_revision = version[0][1:]  # strip off the 'v'
+                    borealis_minor_revision = version[1]
                 else:
                     borealis_major_revision = 255
                     borealis_minor_revision = 255
@@ -439,12 +439,12 @@ class BorealisConvert(BorealisRead):
                 sample_spacing = int(record['tau_spacing'] /
                                      record['tx_pulse_len'])
 
-                # Check to see if tagged version. If not, use 255.255
-                git_hash = record['borealis_git_hash'].split('-')[0]
-                major_version, minor_version = git_hash.split('.')
-                if major_version[0] == 'v':
-                    borealis_major_revision = major_version[1:]
-                    borealis_minor_revision = minor_version
+                # Borealis git tag version numbers. If not a tagged version,
+                # then use 255.255
+                if record['borealis_git_hash'][0] == 'v':  # tagged version, non-tagged versions have hexadecimal
+                    version = record['borealis_git_hash'].split('-')[0].split('.')
+                    borealis_major_revision = version[0][1:]  # strip off the 'v'
+                    borealis_minor_revision = version[1]
                 else:
                     borealis_major_revision = 255
                     borealis_minor_revision = 255

--- a/pydarnio/dmap/superdarn.py
+++ b/pydarnio/dmap/superdarn.py
@@ -322,7 +322,7 @@ class SDarnRead(DmapRead):
 
     # helper function that could be used parallelization
     def _read_darn_record(self, format_fields: List[dict],
-                          optional_list: list = []):
+                          optional_list: Union[List, None] = None):
         """
         Read SuperDARN DMAP records from the DMAP byte array. Several SuperDARN
         field checks are done to insure the integrity of the file.
@@ -357,6 +357,8 @@ class SDarnRead(DmapRead):
                         for incorrect data types for SuperDARN file fields
         """
         record = self.read_record()
+        if optional_list is None:
+            optional_list = []
         SDarnUtilities.missing_field_check(format_fields, record, self.rec_num,
                                            optional_list)
         SDarnUtilities.extra_field_check(format_fields, record, self.rec_num)
@@ -365,7 +367,7 @@ class SDarnRead(DmapRead):
         self._dmap_records.append(record)
 
     def _read_darn_records(self, format_fields: List[dict],
-                           optional_list: list = []):
+                           optional_list: Union[List, None] = None):
         """
         loops over the bytes in the in the SuperDARN byte array and
         calls the helper method read the SuperDARN records from the file/stream
@@ -384,6 +386,8 @@ class SDarnRead(DmapRead):
         --------
         _read_darn_record
         """
+        if optional_list is None:
+            optional_list = []
         self.rec_num = 0  # record number, for exception info
         while self.cursor < self.dmap_end_bytes:
             self._read_darn_record(format_fields, optional_list)
@@ -607,7 +611,8 @@ class SDarnWrite(DmapWrite):
         pyDARNio_log.info("Writing Iqdat file: {}".format(self.filename))
 
         file_struct_list = [superdarn_formats.Iqdat.types]
-        self.superDARN_file_structure_to_bytes(file_struct_list)
+        optional_list = [superdarn_formats.Iqdat.optional_fields]
+        self.superDARN_file_structure_to_bytes(file_struct_list, optional_list)
         with open(self.filename, 'wb') as f:
             f.write(self.dmap_bytearr)
 
@@ -643,7 +648,8 @@ class SDarnWrite(DmapWrite):
                             superdarn_formats.Rawacf.cross_correlation_field,
                             superdarn_formats.Rawacf.digitizing_field,
                             superdarn_formats.Rawacf.fittex_field]
-        self.superDARN_file_structure_to_bytes(file_struct_list)
+        optional_list = [superdarn_formats.Rawacf.optional_fields]
+        self.superDARN_file_structure_to_bytes(file_struct_list, optional_list)
         with open(self.filename, 'wb') as f:
             f.write(self.dmap_bytearr)
 
@@ -726,7 +732,8 @@ class SDarnWrite(DmapWrite):
         file_struct_list = [superdarn_formats.Grid.types,
                             superdarn_formats.Grid.fitted_fields,
                             superdarn_formats.Grid.extra_fields]
-        self.superDARN_file_structure_to_bytes(file_struct_list)
+        optional_list = [superdarn_formats.Grid.optional_fields]
+        self.superDARN_file_structure_to_bytes(file_struct_list, optional_list)
         with open(self.filename, 'wb') as f:
             f.write(self.dmap_bytearr)
 
@@ -770,7 +777,8 @@ class SDarnWrite(DmapWrite):
                             superdarn_formats.Map.fit_fields,
                             superdarn_formats.Map.model_fields,
                             superdarn_formats.Map.hmb_fields]
-        self.superDARN_file_structure_to_bytes(file_struct_list)
+        optional_list = [superdarn_formats.Map.optional_fields]
+        self.superDARN_file_structure_to_bytes(file_struct_list, optional_list)
         with open(self.filename, 'wb') as f:
             f.write(self.dmap_bytearr)
 

--- a/pydarnio/dmap/superdarn_formats.py
+++ b/pydarnio/dmap/superdarn_formats.py
@@ -80,6 +80,7 @@ class Rawacf():
     cross_correlation_field = {
             'xcfd': 'f'
             }
+    optional_fields = {}     # future-proofing
 
 
 class Fitacf():
@@ -254,6 +255,7 @@ class Grid():
         'vector.wdt.median': 'f',
         'vector.wdt.sd': 'f'
     }
+    optional_fields = {}    # future-proofing
 
 
 class Map():
@@ -366,6 +368,7 @@ class Map():
         'vector.wdt.median': 'f',
         'vector.wdt.sd': 'f',
     }
+    optional_fields = {}    # future-proofing
 
 
 class Iqdat():
@@ -434,3 +437,4 @@ class Iqdat():
         'tsze': 'i',
         'data': 'h',
         }
+    optional_fields = {}    # future-proofing


### PR DESCRIPTION
# Scope 

*Several small bugfixes related to Borealis versioning and DMAP file structures.*

**issue:** None

## Approval

**Number of approvals:** *2*

## Test

Try reading/writing any grid, map, fitacf, rawacf, or iqdat file. Previously, I think only fitacf files would actually work. See the docs for how best to do this, I am not well-versed at working with SuperDARN data files, just Borealis files.
https://pydarnio.readthedocs.io/en/latest/user/SDarnRead/#

For the borealis versioning, try converting a v0.5 and v0.6.1 file from rawacf Borealis format to rawacf SuperDARN format. 

```python3
import pydarnio
filename = 'path/to/borealis/file'
outfile = 'path/to/output/file'
converter = pydarnio.BorealisConvert(filename, 'rawacf', outfile, 0)
```

