### PR TITLE
Ignore patch version when determining format for BorealisRestructure.

### DIFF
--- a/pydarnio/borealis/borealis_utilities.py
+++ b/pydarnio/borealis/borealis_utilities.py
@@ -584,5 +584,6 @@ class BorealisUtilities():
                 ''.format(filename))
 
         version = borealis_git_hash.split('-')[0]
+        version = '.'.join(version.split('.')[:2])  # vX.Y, ignore patch revision
 
         return version


### PR DESCRIPTION
# Scope 

Fix bug when trying to restructure Borealis v0.6.1 files with BorealisRestructure.

**Issue:** #50

## Approval

**Number of approvals:** *2*

## Test

```python3
>>> import pydarnio
>>> infile = "20221102.2146.29.sas.0.antennas_iq.hdf5.site"
>>> outfile = "20221102.2146.29.sas.0.antennas_iq.hdf5.test"
>>> pydarnio.BorealisRestructure(infile, outfile, 'antennas_iq', 'array')
BorealisRestructure(20221102.2146.29.sas.0.antennas_iq.hdf5.site, antennas_iq, 20221102.2146.29.sas.0.antennas_iq.hdf5.test)
```

See also discussion on #50 for testing with the regular SuperDARN Canada data flow.
