### PR TITLE
Bugfix for BorealisRestructure

### DIFF
--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1126,7 +1126,7 @@ class BaseFormat():
                     # dims with a determined max value
                     data_buffer = data_dict[k][field]
                     buffer_shape = data_buffer.shape
-                    index_slice = [slice(0, i) for i in buffer_shape]
+                    index_slice = [slice(0, i) for i in buffer_shape if i != 0]
                     # insert record index at start of array's slice list
                     index_slice.insert(0, rec_idx)
                     index_slice = tuple(index_slice)
@@ -1362,7 +1362,7 @@ class BaseFormat():
         first_key = list(records.keys())[0]
         max_ppo_shape = records[first_key]["pulse_phase_offset"].shape
         if max_ppo_shape[0] == 0:
-            return -1
+            return 0
 
         for k in records:
             shape = records[k]["pulse_phase_offset"].shape

--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -329,8 +329,8 @@ class BorealisConvert(BorealisRead):
             if self._is_convertible_to_iqdat():
                 self._convert_bfiq_to_iqdat()
         elif self.sdarn_filetype == 'rawacf':
-            if self._is_convertible_to_rawacf():
-                self._convert_rawacf_to_rawacf()
+            # if self._is_convertible_to_rawacf():
+            self._convert_rawacf_to_rawacf()
         else:  # nothing else is currently supported
             raise borealis_exceptions.BorealisConversionTypesError(
                 self.sdarn_filename, self.borealis_filetype,

--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -329,8 +329,8 @@ class BorealisConvert(BorealisRead):
             if self._is_convertible_to_iqdat():
                 self._convert_bfiq_to_iqdat()
         elif self.sdarn_filetype == 'rawacf':
-            # if self._is_convertible_to_rawacf():
-            self._convert_rawacf_to_rawacf()
+            if self._is_convertible_to_rawacf():
+                self._convert_rawacf_to_rawacf()
         else:  # nothing else is currently supported
             raise borealis_exceptions.BorealisConversionTypesError(
                 self.sdarn_filename, self.borealis_filetype,

--- a/pydarnio/borealis/borealis_formats.py
+++ b/pydarnio/borealis/borealis_formats.py
@@ -2198,10 +2198,11 @@ class BorealisBfiq(BorealisBfiqv0_5):
             'gps_locked': [],
             'gps_to_system_time_diff': [],
             'pulse_phase_offset': [lambda arrays, record_num:
-                            0 if (arrays['pulse_phase_offset'].shape[1] == 0)
-                            else
-                            list((arrays['num_sequences'][record_num],) +
-                            arrays['pulse_phase_offset'][record_num].shape[1:])],
+                                   -1 if arrays['pulse_phase_offset'].size < arrays['num_sequences'][record_num]
+                                   else
+                                   list((arrays['num_sequences'][record_num],)
+                                        + arrays['pulse_phase_offset'][
+                                              record_num].shape[1:])],
             })
         return unshared_fields_dims
 
@@ -2312,7 +2313,11 @@ class BorealisAntennasIq(BorealisAntennasIqv0_5):
             'gps_locked': [],
             'gps_to_system_time_diff': [],
             'pulse_phase_offset': [lambda arrays, record_num:
-                                   arrays['pulse_phase_offset'][record_num]],
+                                   -1 if arrays['pulse_phase_offset'].size < arrays['num_sequences'][record_num]
+                                   else
+                                   list((arrays['num_sequences'][record_num],)
+                                        + arrays['pulse_phase_offset'][
+                                              record_num].shape[1:])],
             })
         return unshared_fields_dims
 

--- a/pydarnio/borealis/borealis_restructure.py
+++ b/pydarnio/borealis/borealis_restructure.py
@@ -349,7 +349,8 @@ class BorealisRestructure(object):
                                 new_data_dict[field] = value
                             elif field in self.format.single_string_fields():
                                 if isinstance(value, bytes):  # This is how single strings are interpreted by h5py
-                                    new_data_dict[field] = self.format.single_element_types()[field](value)
+                                    new_data_dict[field] = self.format.single_element_types()[field](
+                                        value.decode('utf-8'))
                                 elif isinstance(value, h5py.Empty):  # Field is empty
                                     if value.dtype.char == 'S':
                                         new_data_dict[field] = self.format.single_element_types()[field]('')


### PR DESCRIPTION
# Scope 

Restructuring of Borealis files using BorealisRestructure class. Changes run across a couple of files (base_format.py, borealis_formats.py, borealis_restructure.py). 

**Issue:** #51

## Approval

**Number of approvals:** *2*

## Test

I used the scripts in this archive to test. `test_ppo_bugfix.py` is the main file, and you just need to change the directory to wherever you keep the test files in order for it to work. You will also need to incorporate the change from PR #52 (it's a one-liner, you can do this manually). The other file is a supporting script that compares two HDF5 files.

Output when I ran it:

```
/home/remington/borealis/venv/bin/python /home/remington/pyDARNio/tests/test_ppo_bugfix.py
Comparing /data/sample_data/version0.6.1/20221102.2146.29.sas.0.antennas_iq.hdf5 with /data/sample_data/version0.6.1/antennas_iq.hdf5:

Comparing /data/sample_data/version0.6.1//20221102.2146.29.sas.0.bfiq.hdf5 with /data/sample_data/version0.6.1/bfiq.hdf5:

Comparing /data/sample_data/version0.6.1/20221102.2146.29.sas.0.rawacf.hdf5 with /data/sample_data/version0.6.1/rawacf.hdf5:

Comparing /data/sample_data/version0.6.1/20221102.2146.29.sas.0.antennas_iq.hdf5.site with /data/sample_data/version0.6.1/antennas_iq.hdf5.site:

Comparing /data/sample_data/version0.6.1//20221102.2146.29.sas.0.bfiq.hdf5.site with /data/sample_data/version0.6.1/bfiq.hdf5.site:

Comparing /data/sample_data/version0.6.1/20221102.2146.29.sas.0.rawacf.hdf5.site with /data/sample_data/version0.6.1/rawacf.hdf5.site:


Process finished with exit code 0
```

The files I have total about 0.8 GB, so message me if you are testing and I can put them somewhere accessible.

[ppo_bugfix.zip](https://github.com/SuperDARN/pyDARNio/files/10044390/ppo_bugfix.zip)

