### PR TITLE
DEP: Deepdish to h5py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.DS_Store
 
 # C extensions
 *.so

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1273,13 +1273,20 @@ class BaseFormat():
                     rec_dict[dset_name] = data
 
                 # Get the attributes (scalar fields)
-                attribute_dict = {k: v for k, v in group.attrs.items()}
-                attribute_dict.pop('CLASS')       # Inherent to HDF5 file
-                attribute_dict.pop('TITLE')       # Inherent to HDF5 file
-                attribute_dict.pop('VERSION')     # Inherent to HDF5 file
-                for k, v in attribute_dict.items():
-                    if isinstance(v, bytes):
+                attribute_dict = {}
+                for k, v in group.attrs.items():
+                    if k in ['CLASS', 'TITLE', 'VERSION']:
+                        continue
+                    elif isinstance(v, bytes):
                         attribute_dict[k] = v.tobytes().decode('utf-8')
+                    elif isinstance(v, h5py.Empty):
+                        dtype = v.dtype.type
+                        data = dtype()
+                        if isinstance(data, bytes):
+                            data = data.decode('utf-8')
+                        attribute_dict[k] = data
+                    else:
+                        attribute_dict[k] = v
                 rec_dict.update(attribute_dict)
 
                 records[rec_key] = rec_dict
@@ -1326,15 +1333,20 @@ class BaseFormat():
                 arrays[array_name] = data
 
             # Get the attributes (scalar fields)
-            attribute_dict = {k: v for k, v in f.attrs.items()}
-            attribute_dict.pop('CLASS')                     # Inherent to HDF5 file
-            attribute_dict.pop('TITLE')                     # Inherent to HDF5 file
-            attribute_dict.pop('VERSION')                   # Inherent to HDF5 file
-            attribute_dict.pop('DEEPDISH_IO_VERSION')       # Inherent to HDF5 file
-            attribute_dict.pop('PYTABLES_FORMAT_VERSION')   # Inherent to HDF5 file
-            for k, v in attribute_dict.items():
-                if isinstance(v, bytes):
+            attribute_dict = {}
+            for k, v in f.attrs.items():
+                if k in ['CLASS', 'TITLE', 'VERSION', 'DEEPDISH_IO_VERSION', 'PYTABLES_FORMAT_VERSION']:
+                    continue
+                elif isinstance(v, bytes):
                     attribute_dict[k] = v.tobytes().decode('utf-8')
+                elif isinstance(v, h5py.Empty):
+                    dtype = v.dtype.type
+                    data = dtype()
+                    if isinstance(data, bytes):
+                        data = data.decode('utf-8')
+                    attribute_dict[k] = data
+                else:
+                    attribute_dict[k] = v
             arrays.update(attribute_dict)
 
         return arrays

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1230,7 +1230,7 @@ class BaseFormat():
         return timestamp_dict
 
     @classmethod
-    def _read_borealis_records(cls, filename: str) -> OrderedDict:
+    def read_records(cls, filename: str) -> OrderedDict:
         """
         Base function for reading in a Borealis site file.
 
@@ -1287,7 +1287,7 @@ class BaseFormat():
         return records
 
     @classmethod
-    def _read_borealis_arrays(cls, filename: str) -> OrderedDict:
+    def read_arrays(cls, filename: str) -> OrderedDict:
         """
         Base function for reading in a Borealis array file.
 
@@ -1338,6 +1338,79 @@ class BaseFormat():
             arrays.update(attribute_dict)
 
         return arrays
+
+    @classmethod
+    def write_records(cls, filename: str, records: OrderedDict, attribute_types: dict,
+                      dataset_types: dict, compression: str):
+        """
+        Write the file in site style after checking records.
+
+        Several Borealis field checks are done to insure the integrity of the
+        file.
+
+        Parameters
+        ----------
+        filename: str
+            Name of the file to write to.
+        records: OrderedDict
+            Dictionary containing site-formatted fields to write to file.
+        attribute_types: dict
+            Dictionary with the required types for the attributes in the file.
+        dataset_types: dict
+            Dictionary with the require dtypes for the numpy arrays in the
+            file.
+        compression: str
+            Type of compression to use for the HDF5 file.
+        """
+        with h5py.File(filename, 'a') as f:
+            for group_name, group_dict in records.items():
+                group = f.create_group(str(group_name))
+                for k, v in group_dict.items():
+                    if k in attribute_types.keys():
+                        group.attrs[k] = v
+                    elif v.dtype.type == np.str_:
+                        itemsize = v.dtype.itemsize // 4  # every character is 4 bytes
+                        dset = group.create_dataset(k, data=v.view(dtype=(np.uint8)), compression=compression)
+                        dset.attrs['strtype'] = b'unicode'
+                        dset.attrs['itemsize'] = itemsize
+                    else:
+                        group.create_dataset(k, data=v, compression=compression)
+
+    @classmethod
+    def write_arrays(cls, filename: str, arrays: OrderedDict, attribute_types: dict,
+                     dataset_types: dict, unshared_fields: List[str], compression: str):
+        """
+        Write arrays to file while checking all data fields.
+
+        Parameters
+        ----------
+        filename: str
+            Name of the file to write to.
+        arrays: OrderedDict
+            Dictionary containing array-formatted fields to write to file.
+        attribute_types: dict
+            Dictionary with the required types for the attributes in the file.
+        dataset_types: dict
+            Dictionary with the require dtypes for the numpy arrays in the
+            file.
+        unshared_fields: List[str]
+            List of fields that are not shared between the records and
+            therefore should be an array with first dimension = number of
+            records
+        compression: str
+            Type of compression to use for the HDF5 file.
+        """
+        with h5py.File(filename, 'a') as f:
+            for k, v in arrays.items():
+                if k in attribute_types:
+                    f.attrs[k] = v
+                elif v.dtype.type == np.str_:
+                    itemsize = v.dtype.itemsize // 4  # every character is 4 bytes
+                    dset = f.create_dataset(k, data=v.view(dtype=(np.uint8)), compression=compression)
+                    dset.attrs['strtype'] = b'unicode'
+                    dset.attrs['itemsize'] = itemsize
+                else:
+                    f.create_dataset(k, data=v, compression=compression)
 
     # STATIC METHODS COMMON ACROSS FORMATS
     # i.e. common methods that can be used by multiple formats in restructuring

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1357,7 +1357,7 @@ class BaseFormat():
         """
         Write the file in site style after checking records.
 
-        Several Borealis field checks are done to insure the integrity of the
+        Several Borealis field checks are done to ensure the integrity of the
         file.
 
         Parameters

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1102,7 +1102,7 @@ class BaseFormat():
                 datatype = cls.single_element_types()[field]
             else:  # field in array_dtypes
                 datatype = cls.array_dtypes()[field]
-            if datatype == np.unicode_:
+            if datatype == str:
                 # unicode type needs to be explicitly set to have
                 # multiple chars (256)
                 datatype='|U256'
@@ -1110,7 +1110,7 @@ class BaseFormat():
             # Some indices may not be filled due to dimensions that are maximum values (num_sequences, etc. can change
             # between records), so they are initialized with a known value first.
             # Initialize floating-point values to NaN, and integer values to -1.
-            if datatype is np.int64 or datatype is np.uint32:
+            if datatype is np.int64 or datatype is np.uint32 or datatype is np.uint8:
                 empty_array[:] = -1
             else:
                 empty_array[:] = np.NaN

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1379,7 +1379,10 @@ class BaseFormat():
                 group = f.create_group(str(group_name))
                 for k, v in group_dict.items():
                     if k in attribute_types.keys():
-                        group.attrs[k] = v
+                        if isinstance(v, str):
+                            group.attrs[k] = np.bytes_(v)
+                        else:
+                            group.attrs[k] = v
                     elif v.dtype.type == np.str_:
                         itemsize = v.dtype.itemsize // 4  # every character is 4 bytes
                         dset = group.create_dataset(k, data=v.view(dtype=(np.uint8)), compression=compression)
@@ -1415,7 +1418,10 @@ class BaseFormat():
         with h5py.File(filename, 'a') as f:
             for k, v in arrays.items():
                 if k in attribute_types:
-                    f.attrs[k] = v
+                    if isinstance(v, str):
+                        f.attrs[k] = np.bytes_(v)
+                    else:
+                        f.attrs[k] = v
                 elif v.dtype.type == np.str_:
                     itemsize = v.dtype.itemsize // 4  # every character is 4 bytes
                     dset = f.create_dataset(k, data=v.view(dtype=(np.uint8)), compression=compression)

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -37,12 +37,12 @@ Notes
 """
 
 import copy
+import h5py
 import numpy as np
 
 from collections import OrderedDict
 from datetime import datetime
 from typing import Callable, List
-import h5py
 
 from pydarnio import borealis_exceptions
 

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1264,9 +1264,13 @@ class BaseFormat():
                 # Get the datasets (vector fields)
                 datasets = list(group.keys())
                 for dset_name in datasets:
-                    dset = group[dset_name][:]
-                    # TODO: Handle data_descriptors, correlation_descriptors fields (they are gross)
-                    rec_dict[dset_name] = dset
+                    dset = group[dset_name]
+                    if 'strtype' in dset.attrs:     # string type, requires some handling
+                        itemsize = dset.attrs['itemsize']
+                        data = dset[:].view(dtype=(np.unicode_, itemsize))
+                    else:
+                        data = dset[:]      # non-string, can simply load
+                    rec_dict[dset_name] = data
 
                 # Get the attributes (scalar fields)
                 attribute_dict = {k: v for k, v in group.attrs.items()}

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1275,7 +1275,7 @@ class BaseFormat():
                 # Get the attributes (scalar fields)
                 attribute_dict = {}
                 for k, v in group.attrs.items():
-                    if k in ['CLASS', 'TITLE', 'VERSION']:
+                    if k in ['CLASS', 'TITLE', 'VERSION', 'DEEPDISH_IO_VERSION', 'PYTABLES_FORMAT_VERSION']:
                         continue
                     elif isinstance(v, bytes):
                         attribute_dict[k] = v.tobytes().decode('utf-8')

--- a/pydarnio/borealis/base_format.py
+++ b/pydarnio/borealis/base_format.py
@@ -1110,7 +1110,7 @@ class BaseFormat():
             # Some indices may not be filled due to dimensions that are maximum values (num_sequences, etc. can change
             # between records), so they are initialized with a known value first.
             # Initialize floating-point values to NaN, and integer values to -1.
-            if datatype is np.int64 or datatype is np.uint32 or datatype is np.uint8:
+            if datatype in [np.int64, np.uint32, np.uint8]:
                 empty_array[:] = -1
             else:
                 empty_array[:] = np.NaN

--- a/pydarnio/borealis/borealis_array.py
+++ b/pydarnio/borealis/borealis_array.py
@@ -37,6 +37,7 @@ BorealisSiteWrite
 For more information on Borealis data files and how they convert to SDarn
 files, see: https://borealis.readthedocs.io/en/latest/
 """
+import deepdish as dd
 import h5py
 import logging
 
@@ -116,9 +117,7 @@ class BorealisArrayRead():
         # 'vX.X'
         try:
             with h5py.File(self.filename, 'r') as f:
-                records = sorted(list(f.keys()))
-                first_rec = f[records[0]]
-                full_version = first_rec.attrs['borealis_git_hash'].decode('utf-8').split('-')[0]
+                full_version = f.attrs['borealis_git_hash'].decode('utf-8').split('-')[0]
                 version = '.'.join(full_version.split('.')[:2])      # vX.Y, ignore patch revision
         except ValueError as err:
             raise borealis_exceptions.BorealisStructureError(
@@ -284,7 +283,7 @@ class BorealisArrayRead():
         attr_types = self.format.site_single_element_types()
         dataset_types = self.format.site_array_dtypes()
         records = self.format._read_borealis_records
-        while h5py.File(self.filename, 'r') as arrays:
+        with h5py.File(self.filename, 'r') as arrays:
             BorealisUtilities.check_arrays(self.filename, arrays,
                                            attribute_types, dataset_types,
                                            unshared_fields)

--- a/pydarnio/borealis/borealis_array.py
+++ b/pydarnio/borealis/borealis_array.py
@@ -37,7 +37,6 @@ BorealisSiteWrite
 For more information on Borealis data files and how they convert to SDarn
 files, see: https://borealis.readthedocs.io/en/latest/
 """
-import deepdish as dd
 import h5py
 import logging
 import numpy as np

--- a/pydarnio/borealis/borealis_array.py
+++ b/pydarnio/borealis/borealis_array.py
@@ -119,7 +119,7 @@ class BorealisArrayRead():
             with h5py.File(self.filename, 'r') as f:
                 full_version = f.attrs['borealis_git_hash'].decode('utf-8').split('-')[0]
                 version = '.'.join(full_version.split('.')[:2])      # vX.Y, ignore patch revision
-        except ValueError as err:
+        except KeyError as err:
             raise borealis_exceptions.BorealisStructureError(
                 ' {} Could not find the borealis_git_hash required to '
                 'determine read version (file may be site style) {}'

--- a/pydarnio/borealis/borealis_array.py
+++ b/pydarnio/borealis/borealis_array.py
@@ -244,51 +244,13 @@ class BorealisArrayRead():
         dataset_types = self.format.array_array_dtypes()
         unshared_fields = self.format.unshared_fields()
 
-        self._read_borealis_arrays(attribute_types, dataset_types,
-                                   unshared_fields)
+        arrays = self.format._read_borealis_arrays(self.filename)
+        BorealisUtilities.check_arrays(self.filename, arrays,
+                                       attribute_types, dataset_types,
+                                       unshared_fields)
+        self._arrays = arrays
+
         return self._arrays
-
-    def _read_borealis_arrays(self, attribute_types: dict,
-                              dataset_types: dict,
-                              unshared_fields: List[str]):
-        """
-        Read the entire file while checking all data fields.
-
-        Parameters
-        ----------
-        attribute_types: dict
-            Dictionary with the required types for the attributes in the file.
-        dataset_types: dict
-            Dictionary with the require dtypes for the numpy arrays in the
-            file.
-        unshared_fields: List[str]
-            List of fields that are not shared between the records and
-            therefore should be an array with first dimension = number of
-            records
-
-        Raises
-        ------
-        BorealisFieldMissingError - when a field is missing from the Borealis
-                                file
-        BorealisExtraFieldError - when an extra field is present in the
-                                Borealis file
-        BorealisDataFormatTypeError - when a field has the incorrect
-                                field type for the Borealis file
-        BorealisNumberOfRecordsError - when the number of records cannot
-                                be discerned from the arrays
-
-        See Also
-        --------
-        BorealisUtilities
-        """
-        attr_types = self.format.site_single_element_types()
-        dataset_types = self.format.site_array_dtypes()
-        records = self.format._read_borealis_records
-        with h5py.File(self.filename, 'r') as arrays:
-            BorealisUtilities.check_arrays(self.filename, arrays,
-                                           attribute_types, dataset_types,
-                                           unshared_fields)
-            self._arrays = arrays
 
 
 class BorealisArrayWrite():

--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -42,7 +42,6 @@ Update noise values in SDarn fields when these can be calculated.
 """
 import logging
 import numpy as np
-import deepdish as dd
 
 from datetime import datetime
 from typing import Union

--- a/pydarnio/borealis/borealis_formats.py
+++ b/pydarnio/borealis/borealis_formats.py
@@ -262,19 +262,19 @@ class BorealisRawacfv0_4(BaseFormat):
         return {
             # Identifies the version of Borealis that made this data. Necessary
             # for all versions.
-            "borealis_git_hash": np.unicode_,
+            "borealis_git_hash": str,
             # Number used to identify experiment.
             "experiment_id": np.int64,
             # Name of the experiment file.
-            "experiment_name": np.unicode_,
+            "experiment_name": str,
             # Comment about the whole experiment
-            "experiment_comment": np.unicode_,
+            "experiment_comment": str,
             # Additional text comment that describes the slice.
-            "slice_comment": np.unicode_,
+            "slice_comment": str,
             # Number of slices in the experiment at this integration time.
             "num_slices": np.int64,
             # Three letter radar identifier.
-            "station": np.unicode_,
+            "station": str,
             # Number of sampling periods in the integration time.
             "num_sequences": np.int64,
             # range gate separation (equivalent distance between samples), km.
@@ -286,7 +286,7 @@ class BorealisRawacfv0_4(BaseFormat):
             # Sampling rate of the samples being written to file in Hz.
             "rx_sample_rate": np.float64,
             # Designates if the record is the first in a scan.
-            "scan_start_marker": np.bool_,
+            "scan_start_marker": np.uint8,
             # Integration time in seconds.
             "int_time": np.float32,
             # Length of the pulse in microseconds.
@@ -302,7 +302,7 @@ class BorealisRawacfv0_4(BaseFormat):
             "freq": np.uint32,
             # str denoting C data type of the samples included in the data
             # array, such as 'complex float'.
-            "samples_data_type": np.unicode_,
+            "samples_data_type": str,
             # data normalization factor determined by the filter scaling in the
             # decimation scheme.
             "data_normalization_factor": np.float64,
@@ -672,25 +672,25 @@ class BorealisBfiqv0_4(BaseFormat):
         return {
             # Identifies the version of Borealis that made this data. Necessary
             # for all versions.
-            "borealis_git_hash": np.unicode_,
+            "borealis_git_hash": str,
             # Number used to identify experiment.
             "experiment_id": np.int64,
             # Name of the experiment file.
-            "experiment_name": np.unicode_,
+            "experiment_name": str,
             # Comment about the whole experiment
-            "experiment_comment": np.unicode_,
+            "experiment_comment": str,
             # Additional text comment that describes the slice.
-            "slice_comment": np.unicode_,
+            "slice_comment": str,
             # Number of slices in the experiment at this integration time.
             "num_slices": np.int64,
             # Three letter radar identifier.
-            "station": np.unicode_,
+            "station": str,
             # Number of sampling periods in the integration time.
             "num_sequences": np.int64,
             # Sampling rate of the samples being written to file in Hz.
             "rx_sample_rate": np.float64,
             # Designates if the record is the first in a scan.
-            "scan_start_marker": np.bool_,
+            "scan_start_marker": np.uint8,
             # Integration time in seconds.
             "int_time": np.float32,
             # Length of the pulse in microseconds.
@@ -706,7 +706,7 @@ class BorealisBfiqv0_4(BaseFormat):
             "freq": np.uint32,
             # str denoting C data type of the samples included in the data
             # array, such as 'complex float'.
-            "samples_data_type": np.unicode_,
+            "samples_data_type": str,
             # Number of samples in the sampling period.
             "num_samps": np.uint32,
             # range gate separation (equivalent distance between samples), km
@@ -1074,25 +1074,25 @@ class BorealisAntennasIqv0_4(BaseFormat):
         return {
             # Identifies the version of Borealis that made this data. Necessary
             # for all versions.
-            "borealis_git_hash": np.unicode_,
+            "borealis_git_hash": str,
             # Number used to identify experiment.
             "experiment_id": np.int64,
             # Name of the experiment file.
-            "experiment_name": np.unicode_,
+            "experiment_name": str,
             # Comment about the whole experiment
-            "experiment_comment": np.unicode_,
+            "experiment_comment": str,
             # Additional text comment that describes the slice.
-            "slice_comment": np.unicode_,
+            "slice_comment": str,
             # Number of slices in the experiment at this integration time.
             "num_slices": np.int64,
             # Three letter radar identifier.
-            "station": np.unicode_,
+            "station": str,
             # Number of sampling periods in the integration time.
             "num_sequences": np.int64,
             # Sampling rate of the samples being written to file in Hz.
             "rx_sample_rate": np.float64,
             # Designates if the record is the first in a scan.
-            "scan_start_marker": np.bool_,
+            "scan_start_marker": np.uint8,
             # Integration time in seconds.
             "int_time": np.float32,
             # Length of the pulse in microseconds.
@@ -1108,7 +1108,7 @@ class BorealisAntennasIqv0_4(BaseFormat):
             "freq": np.uint32,
             # str denoting C data type of the samples included in the data
             # array, such as 'complex float'.
-            "samples_data_type": np.unicode_,
+            "samples_data_type": str,
             # Number of samples in the sampling period.
             "num_samps": np.uint32,
             # data normalization factor determined by the filter scaling in the
@@ -1402,23 +1402,23 @@ class BorealisRawrfv0_4(BaseFormat):
         return {
             # Identifies the version of Borealis that made this data. Necessary
             # for all versions.
-            "borealis_git_hash": np.unicode_,
+            "borealis_git_hash": str,
             # Number used to identify experiment.
             "experiment_id": np.int64,
             # Name of the experiment file.
-            "experiment_name": np.unicode_,
+            "experiment_name": str,
             # Comment about the whole experiment
-            "experiment_comment": np.unicode_,
+            "experiment_comment": str,
             # Number of slices in the experiment at this integration time.
             "num_slices": np.int64,
             # Three letter radar identifier.
-            "station": np.unicode_,
+            "station": str,
             # Number of sampling periods in the integration time.
             "num_sequences": np.int64,
             # Sampling rate of the samples being written to file in Hz.
             "rx_sample_rate": np.float64,
             # Designates if the record is the first in a scan.
-            "scan_start_marker": np.bool_,
+            "scan_start_marker": np.uint8,
             # Integration time in seconds.
             "int_time": np.float32,
             # Number of main array antennas.
@@ -1427,7 +1427,7 @@ class BorealisRawrfv0_4(BaseFormat):
             "intf_antenna_count": np.uint32,
             # str denoting C data type of the samples included in the data
             # array, such as 'complex float'.
-            "samples_data_type": np.unicode_,
+            "samples_data_type": str,
             # The center frequency of this data in kHz
             "rx_center_freq": np.float64,
             # Number of samples in the sampling period.
@@ -1513,12 +1513,12 @@ class BorealisRawacfv0_5(BorealisRawacfv0_4):
             # the slice id of the file and dataset.
             "slice_id": np.uint32,
             # the interfacing of this slice to other slices.
-            "slice_interfacing": np.unicode_,
+            "slice_interfacing": str,
             # A string describing the type of scheduling time at the time of
             # this dataset.
-            "scheduling_mode": np.unicode_,
+            "scheduling_mode": str,
             # A string describing the averaging method, ex. mean, median
-            "averaging_method": np.unicode_,
+            "averaging_method": str,
             # number of blanked samples in the sequence.
             "num_blanked_samples": np.uint32
             })
@@ -1663,10 +1663,10 @@ class BorealisBfiqv0_5(BorealisBfiqv0_4):
             # the slice id of the file and dataset.
             "slice_id": np.uint32,
             # the interfacing of this slice to other slices.
-            "slice_interfacing": np.unicode_,
+            "slice_interfacing": str,
             # A string describing the type of scheduling time at the time of
             # this dataset.
-            "scheduling_mode": np.unicode_,
+            "scheduling_mode": str,
             # number of blanked samples in the sequence.
             "num_blanked_samples": np.uint32
             })
@@ -1806,10 +1806,10 @@ class BorealisAntennasIqv0_5(BorealisAntennasIqv0_4):
             # the slice id of the file and dataset.
             "slice_id": np.uint32,
             # the interfacing of this slice to other slices.
-            "slice_interfacing": np.unicode_,
+            "slice_interfacing": str,
             # A string describing the type of scheduling time at the time of
             # this dataset.
-            "scheduling_mode": np.unicode_,
+            "scheduling_mode": str,
             # number of blanked samples in the sequence.
             "num_blanked_samples": np.uint32
             })
@@ -1955,7 +1955,7 @@ class BorealisRawrfv0_5(BorealisRawrfv0_4):
         single_element_types.update({
             # A string describing the type of scheduling time at the time of
             # this dataset.
-            "scheduling_mode": np.unicode_
+            "scheduling_mode": str
             })
         return single_element_types
 

--- a/pydarnio/borealis/borealis_formats.py
+++ b/pydarnio/borealis/borealis_formats.py
@@ -2044,7 +2044,7 @@ class BorealisRawacf(BorealisRawacfv0_5):
             "lp_status_word": np.uint32,
             # Boolean indicating if the GPS was locked during the entire
             # integration period
-            "gps_locked": np.bool_,
+            "gps_locked": np.uint8,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
             "gps_to_system_time_diff": np.float64,
@@ -2152,7 +2152,7 @@ class BorealisBfiq(BorealisBfiqv0_5):
             "lp_status_word": np.uint32,
             # Boolean indicating if the GPS was locked during the entire
             # integration period
-            "gps_locked": np.bool_,
+            "gps_locked": np.uint8,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
             "gps_to_system_time_diff": np.float64,
@@ -2267,7 +2267,7 @@ class BorealisAntennasIq(BorealisAntennasIqv0_5):
             "lp_status_word": np.uint32,
             # Boolean indicating if the GPS was locked during the entire
             # integration period
-            "gps_locked": np.bool_,
+            "gps_locked": np.uint8,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
             "gps_to_system_time_diff": np.float64,
@@ -2374,7 +2374,7 @@ class BorealisRawrf(BorealisRawrfv0_5):
             "lp_status_word": np.uint32,
             # Boolean indicating if the GPS was locked during the entire
             # integration period
-            "gps_locked": np.bool_,
+            "gps_locked": np.uint8,
             # The max time diffe between GPS and system time during the
             # integration period. In seconds. Negative if GPS time ahead.
             "gps_to_system_time_diff": np.float64,

--- a/pydarnio/borealis/borealis_restructure.py
+++ b/pydarnio/borealis/borealis_restructure.py
@@ -410,7 +410,7 @@ class BorealisRestructure(object):
                             # change between records), so they are initialized
                             # with a known value first. Initialize floating-
                             # point values to NaN, and integer values to -1.
-                            if datatype is np.int64 or datatype is np.uint32 or datatype is np.uint8:
+                            if datatype in [np.int64, np.uint32, np.uint8]:
                                 empty_array[:] = -1
                             else:
                                 empty_array[:] = np.NaN

--- a/pydarnio/borealis/borealis_restructure.py
+++ b/pydarnio/borealis/borealis_restructure.py
@@ -214,7 +214,7 @@ class BorealisRestructure(object):
                     if field in attribute_types:
                         data = f.attrs[field]
                         if isinstance(data, bytes):
-                            data = str(data)
+                            data = data.decode('utf-8')
                     elif field in self.format.array_string_fields():
                         dset = f[field]
                         itemsize = dset.attrs['itemsize']

--- a/pydarnio/borealis/borealis_restructure.py
+++ b/pydarnio/borealis/borealis_restructure.py
@@ -219,12 +219,12 @@ class BorealisRestructure(object):
             with hdf5.File(self.infile_name, 'r') as f:
                 for field in self.format.unshared_fields():
                     if field in self.format.single_element_types():
-                    unshared_single_elements[field] = f[field]
+                        unshared_single_elements[field] = f[field]
 
             with h5py.File(self.infile_name, 'r') as f:
                 records = sorted(list(f.keys()))
                 first_rec = f[records[0]]
-                sqn_timestamps_array = first_rec.attrs['sqn_timestamps']
+                sqn_timestamps_array = first_rec.attrs['sqn_timestamps']\
                                             .decode('utf-8')
             for record_num, seq_timestamp in enumerate(sqn_timestamps_array):
                 # format dictionary key in the same way it is done
@@ -439,7 +439,7 @@ class BorealisRestructure(object):
             BorealisUtilities.check_arrays(self.infile_name, new_data_dict,
                                            attribute_types, dataset_types,
                                            unshared_fields)
-            while h5py.File(self.outfile_name, 'w') as f:
+            with h5py.File(self.outfile_name, 'w') as f:
                 f.create_dataset(new_data_dict, compression=self.compression)
 
         except TypeError as err:
@@ -490,7 +490,7 @@ class BorealisRestructure(object):
         tmp_filename = self.outfile_name + '.tmp'
         Path(tmp_filename).touch()
 
-        while h5py.File(tmp_filename, 'w') as f:
+        with h5py.File(tmp_filename, 'w') as f:
             f.create_dataset(record[record_name], compression=self.compression)
         
         cp_cmd = 'h5copy -i {newfile} -o {full_file} -s / -d {dtstr}'

--- a/pydarnio/borealis/borealis_restructure.py
+++ b/pydarnio/borealis/borealis_restructure.py
@@ -378,7 +378,7 @@ class BorealisRestructure(object):
                                 # Initialize array now with correct data type.
                                 dtype = self.format.single_element_types()[field]
                                 new_data_dict[field] = np.empty(num_records, dtype=dtype)
-                                if dtype is np.int64 or dtype is np.uint32 or dtype is np.uint8:
+                                if dtype in [np.int64, np.uint32, np.uint8]:
                                     new_data_dict[field][:] = -1
                                 else:
                                     new_data_dict[field][:] = np.NaN

--- a/pydarnio/borealis/borealis_site.py
+++ b/pydarnio/borealis/borealis_site.py
@@ -129,7 +129,7 @@ class BorealisSiteRead():
                 records = sorted(list(f.keys()))
                 first_rec = f[records[0]]
                 full_version = first_rec.attrs['borealis_git_hash'].decode('utf-8').split('-')[0]
-                version = '.'.join(version.split('.')[:2])      # vX.Y, ignore patch revision
+                version = '.'.join(full_version.split('.')[:2])      # vX.Y, ignore patch revision
         except (IndexError, ValueError) as err:
             # if this is an array style file, it will raise
             # IndexError on the array.

--- a/pydarnio/borealis/borealis_site.py
+++ b/pydarnio/borealis/borealis_site.py
@@ -35,7 +35,6 @@ Future Work
 Add compression to bzip2
 
 """
-import deepdish as dd
 import h5py
 import logging
 import os
@@ -523,8 +522,9 @@ class BorealisSiteWrite():
         tmp_filename = self.filename + '.tmp'
         Path(tmp_filename).touch()
         for group_name, group_dict in self.records.items():
-            dd.io.save(tmp_filename, {str(group_name): group_dict},
-                       compression=self.compression)
+            with h5py.File(tmp_filename, 'w') as f:
+                f.create_dataset(str(group_name), data=group_dict,
+                                 compression=self.compression)
             cp_cmd = 'h5copy -i {newfile} -o {full_file} -s {dtstr} -d {dtstr}'
             cmd = cp_cmd.format(newfile=tmp_filename, full_file=self.filename,
                                 dtstr='/'+str(group_name))

--- a/pydarnio/borealis/borealis_utilities.py
+++ b/pydarnio/borealis/borealis_utilities.py
@@ -562,7 +562,7 @@ class BorealisUtilities():
         """
         if structure == 'array':
             try:
-                with h5py.File(self.filename, 'r') as f:
+                with h5py.File(filename, 'r') as f:
                     borealis_git_hash = f.attrs['borealis_git_hash'].decode('utf-8')
             except KeyError as err:
                 raise borealis_exceptions.BorealisStructureError(

--- a/pydarnio/borealis/borealis_utilities.py
+++ b/pydarnio/borealis/borealis_utilities.py
@@ -28,7 +28,6 @@ class
 
 """
 import logging
-import deepdish as dd
 import h5py
 import numpy as np
 import sys
@@ -560,8 +559,10 @@ class BorealisUtilities():
         """
         if structure == 'array':
             try:
-                borealis_git_hash = dd.io.load(filename,
-                                               group='/borealis_git_hash')
+                with h5py.File(self.filename, 'r') as f:
+                    records = sorted(list(f.keys()))
+                    borealis_git_hash = records.attrs['borealis_git_hash']
+                                            .decode('utf-8')
             except ValueError as err:
                 raise borealis_exceptions.BorealisStructureError(
                     ' {} Could not find the borealis_git_hash required to '
@@ -569,9 +570,11 @@ class BorealisUtilities():
                     ''.format(filename, err)) from err
         elif structure == 'site':
             try:
-                borealis_git_hash = \
-                    dd.io.load(filename, group='/{}/borealis_git_hash'
-                                               ''.format(record_names[0]))
+                with h5py.File(self.filename, 'r') as f:
+                    records = sorted(list(f.keys()))
+                    first_rec = f[records[0]]
+                    borealis_git_hash = first_rec.attrs['borealis_git_hash']
+                                            .decode('utf-8')
             except ValueError as err:
                 raise borealis_exceptions.BorealisStructureError(
                     ' {} Could not find the borealis_git_hash required to '

--- a/pydarnio/borealis/borealis_utilities.py
+++ b/pydarnio/borealis/borealis_utilities.py
@@ -262,7 +262,8 @@ class BorealisUtilities():
         incorrect_types_check = {param: str(attributes_type_dict[param])
                                  for param in attributes_type_dict.keys()
                                  if type(record[param]) !=
-                                 attributes_type_dict[param]}
+                                 attributes_type_dict[param] and
+                                 record[param].shape is not None}
 
         incorrect_types_check.update({param: 'np.ndarray of ' +
                                       str(datasets_type_dict[param])
@@ -321,7 +322,8 @@ class BorealisUtilities():
         incorrect_types_check = {param: str(attributes_type_dict[param])
                                  for param in attributes_type_dict.keys()
                                  if type(file_data[param]) !=
-                                 attributes_type_dict[param]}
+                                 attributes_type_dict[param] and
+                                 file_data[param].shape is not None}
 
         datasets_type_dict_keys = sorted(list(datasets_type_dict.keys()))
         np_array_types = [isinstance(file_data[param], np.ndarray) for param in
@@ -342,7 +344,8 @@ class BorealisUtilities():
                                       str(datasets_type_dict[param])
                                       for param in datasets_type_dict.keys()
                                       if file_data[param].dtype.type !=
-                                      datasets_type_dict[param]})
+                                      datasets_type_dict[param] and
+                                      file_data[param].dtype.type != np.str_})
         if len(incorrect_types_check) > 0:
             raise borealis_exceptions.\
                     BorealisDataFormatTypeError(filename,

--- a/pydarnio/borealis/borealis_utilities.py
+++ b/pydarnio/borealis/borealis_utilities.py
@@ -561,7 +561,7 @@ class BorealisUtilities():
             try:
                 with h5py.File(self.filename, 'r') as f:
                     records = sorted(list(f.keys()))
-                    borealis_git_hash = records.attrs['borealis_git_hash']
+                    borealis_git_hash = records.attrs['borealis_git_hash']\
                                             .decode('utf-8')
             except ValueError as err:
                 raise borealis_exceptions.BorealisStructureError(
@@ -573,7 +573,7 @@ class BorealisUtilities():
                 with h5py.File(self.filename, 'r') as f:
                     records = sorted(list(f.keys()))
                     first_rec = f[records[0]]
-                    borealis_git_hash = first_rec.attrs['borealis_git_hash']
+                    borealis_git_hash = first_rec.attrs['borealis_git_hash']\
                                             .decode('utf-8')
             except ValueError as err:
                 raise borealis_exceptions.BorealisStructureError(

--- a/pydarnio/borealis/borealis_utilities.py
+++ b/pydarnio/borealis/borealis_utilities.py
@@ -563,22 +563,20 @@ class BorealisUtilities():
         if structure == 'array':
             try:
                 with h5py.File(self.filename, 'r') as f:
-                    records = sorted(list(f.keys()))
-                    borealis_git_hash = records.attrs['borealis_git_hash']\
-                                            .decode('utf-8')
-            except ValueError as err:
+                    borealis_git_hash = f.attrs['borealis_git_hash'].decode('utf-8')
+            except KeyError as err:
                 raise borealis_exceptions.BorealisStructureError(
                     ' {} Could not find the borealis_git_hash required to '
                     'determine file version. Data file may be corrupted. {}'
                     ''.format(filename, err)) from err
         elif structure == 'site':
             try:
-                with h5py.File(self.filename, 'r') as f:
+                with h5py.File(filename, 'r') as f:
                     records = sorted(list(f.keys()))
                     first_rec = f[records[0]]
                     borealis_git_hash = first_rec.attrs['borealis_git_hash']\
                                             .decode('utf-8')
-            except ValueError as err:
+            except KeyError as err:
                 raise borealis_exceptions.BorealisStructureError(
                     ' {} Could not find the borealis_git_hash required to '
                     'determine file version. Data file may be corrupted. {}'

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ setup(
     author="SuperDARN",
     include_package_data=True,
     setup_requires=['pyyaml', 'numpy',
-                    'h5py', 'deepdish', 'pathlib2'],
+                    'h5py>=3.3.0', 'deepdish', 'pathlib2'],
     # pyyaml library install
     install_requires=['pyyaml', 'numpy',
-                      'h5py', 'deepdish', 'pathlib2']
+                      'h5py>=3.3.0', 'deepdish', 'pathlib2']
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author="SuperDARN",
     include_package_data=True,
     setup_requires=['pyyaml', 'numpy',
-                    'h5py>=3.3.0', 'deepdish', 'pathlib2'],
+                    'h5py>=3.3.0', 'pathlib2'],
     # pyyaml library install
     install_requires=['pyyaml', 'numpy',
                       'h5py>=3.3.0', 'deepdish', 'pathlib2']


### PR DESCRIPTION
# Scope 

The deepdish library is not being maintained any longer so we are going to move to using h5py solely. Instances of deeepdish use in the borealis package need updating. This PR is to track those changes.

**issue:** #58 

## Approval

**Number of approvals:** 2

## Test

Will provide when testing needed. 

*Reminder:
  - Modification line to be filled in *

