### PR TITLE
Added tx_antenna_mag field to Borealis v0.7 file type.

### DIFF
--- a/pydarnio/borealis/borealis_convert.py
+++ b/pydarnio/borealis/borealis_convert.py
@@ -907,6 +907,17 @@ class BorealisConvert(BorealisRead):
             else:
                 lp_sw = record_dict['lp_status_word']
 
+            # TX Antenna Mag only introduced in Borealis v0.7 onwards, so txpow defaults to -1 if not present.
+            # If present, txpow is a bitfield mapping of whether each antenna was transmitting. Antenna 15 is the
+            # MSB, and Antenna 0 the LSB. Since txpow is a signed int in DMAP, -1 means all antennas transmitting.
+            if 'tx_antenna_mag' not in record_dict.keys():
+                txpow = -1      # This is the same as if all antennas were transmitting.
+            else:
+                txpow = np.uint16()
+                for i in range(len(record_dict['tx_antenna_mag'])):
+                    if record_dict['tx_antenna_mag'][i] > 0:
+                        txpow += 1 << i
+
             sdarn_record_dict = {
                 'radar.revision.major': np.int8(borealis_major_revision),
                 'radar.revision.minor': np.int8(borealis_minor_revision),
@@ -948,7 +959,7 @@ class BorealisConvert(BorealisRead):
                                     utcfromtimestamp(
                                         record_dict['sqn_timestamps'][0]).
                                     microsecond),
-                'txpow': np.int16(-1),
+                'txpow': np.int16(txpow),
                 # see Borealis documentation
                 'nave': np.int16(record_dict['num_sequences']),
                 'atten': np.int16(0),

--- a/pydarnio/borealis/borealis_formats.py
+++ b/pydarnio/borealis/borealis_formats.py
@@ -517,6 +517,7 @@ class BorealisFields(BorealisFieldsv0_6):
         field_file_mapping['lags'].append('antennas_iq')
         field_file_mapping['num_ranges'].append('antennas_iq')
         field_file_mapping['range_sep'].append('antennas_iq')
+        field_file_mapping['tx_antenna_mag'] = ['antennas_iq', 'bfiq', 'rawacf', 'rawrf']
 
         return field_file_mapping
 
@@ -560,6 +561,7 @@ class BorealisFields(BorealisFieldsv0_6):
         all_arrays.update({
             "antenna_arrays_order": np.bytes_,
             "data_descriptors": np.bytes_,
+            "tx_antenna_mag": np.float32,
         })
         all_arrays.pop('correlation_dimensions')
         all_arrays.pop('correlation_descriptors')


### PR DESCRIPTION
* Parse the field in order to set txpow in DMAP files.

# Scope 

Adding a new field to the Borealis v0.7 format.

**issue: N/A**

## Approval

**Number of approvals:** *1*

## Test

Will provide a test file once I've generated one.


