### PR TITLE
Add support for SND-format files

### DIFF
--- a/pydarnio/dmap/dmap.py
+++ b/pydarnio/dmap/dmap.py
@@ -861,6 +861,7 @@ class DmapWrite(object):
                                                       - Iqdat
                                                       - Rawacf
                                                       - Fitacf
+                                                      - Snd
                                                       - Grid
                                                       - Map
 
@@ -876,6 +877,7 @@ class DmapWrite(object):
                                      - 'iqdat' : SuperDARN file type
                                      - 'rawacf' : SuperDARN file type
                                      - 'fitacf' : SuperDARN file type
+                                     - 'snd' : SuperDARN file type
                                      - 'grid' : SuperDARN file type
                                      - 'map' : SuperDARN file type
                                      - 'dmap' : writes a file in DMap format

--- a/pydarnio/dmap/superdarn.py
+++ b/pydarnio/dmap/superdarn.py
@@ -6,6 +6,7 @@ The file types that are supported:
     - Iqdat
     - Rawacf
     - Fitacf
+    - Snd
     - Grid
     - Map
 
@@ -254,6 +255,7 @@ class SDarnRead(DmapRead):
         Iqdat
         Rawacf
         Fitacf
+        Snd
         Grid
         Map
     ...
@@ -281,6 +283,8 @@ class SDarnRead(DmapRead):
         reads and checks rawacf DMAP binary data
     read_fitacf()
         reads and checks fitacf DMAP binary data
+    read_snd()
+        reads and checks snd DMAP binary data
     read_grid()
         reads and checks grid DMAP binary data
     read_map()
@@ -470,6 +474,26 @@ class SDarnRead(DmapRead):
         self.records = dmap2dict(self._dmap_records)
         return self.records
 
+    def read_snd(self) -> List[dict]:
+        """
+        Reads Snd DMAP file/stream
+
+        Returns
+        -------
+        dmap_records : List[dict]
+            DMAP record of the Snd data
+        """
+        pyDARNio_log.info("Reading Snd file: {}".format(self.dmap_file))
+
+        file_struct_list = [superdarn_formats.Snd.types,
+                            superdarn_formats.Snd.optional_fields,
+                            superdarn_formats.Snd.fitted_fields,
+                            superdarn_formats.Snd.xcf_fields]
+        optional_list = [superdarn_formats.Snd.optional_fields]
+        self._read_darn_records(file_struct_list, optional_list)
+        self.records = dmap2dict(self._dmap_records)
+        return self.records
+
     def read_grid(self) -> List[dict]:
         """
         Reads Grid DMAP file/stream
@@ -538,11 +562,14 @@ class SDarnWrite(DmapWrite):
     write_iqdat(filename)
         Writes dmap records to SuperDARN IQDAT file structure
         with the given filename
-    write_fitacf(filename)
+    write_rawacf(filename)
         Write dmap records to SuperDARN RAWACF file structure
         with the given filename
-    write_rawacf(filename)
+    write_fitacf(filename)
         Writes dmap records to SuperDARN FITACF file structure
+        with the given filename
+    write_snd(filename)
+        Writes dmap records to SuperDARN SND file structure
         with the given filename
     write_grid(filename)
         Writes dmap records to SuperDARN GRID file structure
@@ -693,6 +720,44 @@ class SDarnWrite(DmapWrite):
                             superdarn_formats.Fitacf.xcf_fields_fitacf2
                            ]
         optional_list = [superdarn_formats.Fitacf.optional_fields]
+        self.superDARN_file_structure_to_bytes(file_struct_list, optional_list)
+        with open(self.filename, 'wb') as f:
+            f.write(self.dmap_bytearr)
+
+    def write_snd(self, filename: str = ""):
+        """
+        Writes SuperDARN file type SND
+
+        Parameters
+        -----------
+        filename : str
+            The name of the SND file including path
+
+
+        Raises
+        -------
+        superDARNExtraFieldError - if there is an extra field
+        SuperDARNFieldMissingError- if there is an missing field
+        SuperDARNDataFormatTypeError - if there is a formatting error
+                               like an incorrect data type format
+
+        See Also
+        ---------
+        extra_field_check
+        missing_field_check
+        superdarn_formats.Snd - module contain the data types
+                                 in each SuperDARN files types
+        """
+        pyDARNio_log.info("Writing Snd file: {}".format(self.filename))
+
+        self._filename_check(filename)
+        self._empty_record_check()
+        file_struct_list = [superdarn_formats.Snd.types,
+                            superdarn_formats.Snd.optional_fields,
+                            superdarn_formats.Snd.fitted_fields,
+                            superdarn_formats.Snd.xcf_fields
+                           ]
+        optional_list = [superdarn_formats.Snd.optional_fields]
         self.superDARN_file_structure_to_bytes(file_struct_list, optional_list)
         with open(self.filename, 'wb') as f:
             f.write(self.dmap_bytearr)

--- a/pydarnio/dmap/superdarn_formats.py
+++ b/pydarnio/dmap/superdarn_formats.py
@@ -482,8 +482,8 @@ class Snd():
         'combf': 's',
         'fitacf.revision.major': 'i',
         'fitacf.revision.minor': 'i',
-        'snd.revision.major': 'i',
-        'snd.revision.minor': 'i'}
+        'snd.revision.major': 'h',
+        'snd.revision.minor': 'h'}
     # Fields added if the data is good and can be
     # fitted
     fitted_fields = {

--- a/pydarnio/dmap/superdarn_formats.py
+++ b/pydarnio/dmap/superdarn_formats.py
@@ -438,3 +438,65 @@ class Iqdat():
         'data': 'h',
         }
     optional_fields = {}    # future-proofing
+
+
+
+class Snd():
+    """
+    Class containing Snd fields
+    """
+    # Standard fields
+    types = {
+        'radar.revision.major': 'c',
+        'radar.revision.minor': 'c',
+        'origin.code': 'c',
+        'origin.time': 's',
+        'origin.command': 's',
+        'cp': 'h',
+        'stid': 'h',
+        'time.yr': 'h',
+        'time.mo': 'h',
+        'time.dy': 'h',
+        'time.hr': 'h',
+        'time.mt': 'h',
+        'time.sc': 'h',
+        'time.us': 'i',
+        'nave': 'h',
+        'lagfr': 'h',
+        'smsep': 'h',
+        'noise.search': 'f',
+        'noise.mean': 'f',
+        'channel': 'h',
+        'bmnum': 'h',
+        'bmazm': 'f',
+        'scan': 'h',
+        'rxrise': 'h',
+        'intt.sc': 'h',
+        'intt.us': 'i',
+        'nrang': 'h',
+        'frang': 'h',
+        'rsep': 'h',
+        'xcf': 'h',
+        'tfreq': 'h',
+        'noise.sky': 'f',
+        'combf': 's',
+        'fitacf.revision.major': 'i',
+        'fitacf.revision.minor': 'i',
+        'snd.revision.major': 'i',
+        'snd.revision.minor': 'i'}
+    # Fields added if the data is good and can be
+    # fitted
+    fitted_fields = {
+        'slist': 'h',
+        'qflg': 'c',
+        'gflg': 'c',
+        'v': 'f',
+        'v_e': 'f',
+        'p_l': 'f',
+        'w_l': 'f'}
+
+    xcf_fields = {
+        'phi0': 'f',
+        'phi0_e': 'f',
+    }
+    optional_fields = {}    # future-proofing

--- a/pydarnio/dmap/superdarn_formats.py
+++ b/pydarnio/dmap/superdarn_formats.py
@@ -496,6 +496,7 @@ class Snd():
         'w_l': 'f'}
 
     xcf_fields = {
+        'x_qflg': 'c',
         'phi0': 'f',
         'phi0_e': 'f',
     }


### PR DESCRIPTION
# Scope 

This pull request adds support for `snd`-format dmap files (C and IDL support added to the RST in https://github.com/SuperDARN/rst/pull/315).

## Approval

**Number of approvals:** 1 (?)

## Test

To test, try opening / reading a `snd`-format file produced either on-site by a radar or by converting a `fitacf`-format file via the `make_snd` binary in the RST.  I can provide a test file if requested.