### PR TITLE
Minor bugfix with checking scalar type format when reading DMAP.

### DIFF
--- a/pydarnio/dmap/dmap.py
+++ b/pydarnio/dmap/dmap.py
@@ -510,7 +510,7 @@ class DmapRead():
         scalar_type_fmt = DMAP_DATA_TYPES[scalar_type][0]
         scalar_fmt_byte = DMAP_DATA_TYPES[scalar_type][1]
 
-        if scalar_type_fmt != DMAP:
+        if scalar_type_fmt != '':
             scalar_value = self.read_data(scalar_type_fmt, scalar_fmt_byte)
         else:
             message = "Error: Trying to read DMap data type for a scalar."\


### PR DESCRIPTION
# Scope 

Small bugfix for reading DMAP files. If string field such as `combf` contained null bytes in the middle of the string, the error thrown was not very helpful as the check for improper scalar data type was improperly conducted. The old error was:

```
Traceback (most recent call last):
  File "/home/remington/pyDARNio/tests/test_dmap.py", line 8, in <module>
    data = reader.read_rawacf()
  File "/home/remington/pyDARNio/pydarnio/dmap/superdarn.py", line 446, in read_rawacf
    self._read_darn_records(file_struct_list)
  File "/home/remington/pyDARNio/pydarnio/dmap/superdarn.py", line 397, in _read_darn_records
    self._read_darn_record(format_fields, optional_list)
  File "/home/remington/pyDARNio/pydarnio/dmap/superdarn.py", line 363, in _read_darn_record
    record = self.read_record()
  File "/home/remington/pyDARNio/pydarnio/dmap/dmap.py", line 465, in read_record
    scalar = self.read_scalar()
  File "/home/remington/pyDARNio/pydarnio/dmap/dmap.py", line 514, in read_scalar
    scalar_value = self.read_data(scalar_type_fmt, scalar_fmt_byte)
  File "/home/remington/pyDARNio/pydarnio/dmap/dmap.py", line 722, in read_data
    return data[0]
IndexError: tuple index out of range
```

**issue:** N/A

## Approval

**Number of approvals:** 1

## Test

Contact me or reply to this PR to get a data file that is corrupted in this way. 

Testing is as simple as:

```python3
import pydarnio
infile = '/path/to/file'
reader = pydarnio.SDarnRead(infile)
data = reader.read_rawacf()
```
If everything is done correctly, it should throw the following error: 
```
DmapDataError:  The following error for /path/to/file was raised: Error: Trying to read DMap data type for a scalar. Failed at record 0
```

