### PR TITLE
Adding support for new srng (slant range) field in grid and map files

### DIFF
--- a/pydarnio/dmap/superdarn_formats.py
+++ b/pydarnio/dmap/superdarn_formats.py
@@ -256,7 +256,7 @@ class Grid():
         'vector.wdt.sd': 'f'
     }
     optional_fields = {
-        'vector.srng': 'f'}
+        'vector.srng': 'f'
     }
 
 
@@ -371,7 +371,7 @@ class Map():
         'vector.wdt.sd': 'f',
     }
     optional_fields = {
-        'vector.srng': 'f'}
+        'vector.srng': 'f'
     }
 
 

--- a/pydarnio/dmap/superdarn_formats.py
+++ b/pydarnio/dmap/superdarn_formats.py
@@ -255,7 +255,9 @@ class Grid():
         'vector.wdt.median': 'f',
         'vector.wdt.sd': 'f'
     }
-    optional_fields = {}    # future-proofing
+    optional_fields = {
+        'vector.srng': 'f'}
+    }
 
 
 class Map():
@@ -368,7 +370,10 @@ class Map():
         'vector.wdt.median': 'f',
         'vector.wdt.sd': 'f',
     }
-    optional_fields = {}    # future-proofing
+    optional_fields = {
+        'vector.srng': 'f'}
+    }
+
 
 
 class Iqdat():


### PR DESCRIPTION
# Scope 

This pull request adds support for a new (optional) `vector.srng` field being added to `grid` and `map`-format dmap files in the RST (https://github.com/SuperDARN/rst/pull/616).

## Approval

**Number of approvals:** 1 (?)

## Test

To test, try creating a `grid` file using `make_grid` with the RST's [feature/grid_slant_range](https://github.com/SuperDARN/rst/tree/feature/grid_slant_range) branch, and then try opening / reading the `grid` file with this branch.  Or I can provide a test file if needed.
